### PR TITLE
Adapt to pkgconf 2.5.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,11 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         cip:
-          - tag: "5.35"
-          - tag: "5.34"
-          - tag: "5.34"
+          - tag: "5.37"
+          - tag: "5.36"
+          - tag: "5.36"
             install_from_git: 1
-          - tag: "5.34-fedora34"
+          - tag: "5.36-fedora34"
+          - tag: "5.34"
           - tag: "5.32"
           - tag: "5.30"
           - tag: "5.28"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -55,7 +55,7 @@ jobs:
           cip cache-key
 
       - name: Cache CPAN modules
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ~/.cip
           key: ${{ runner.os }}-build-${{ steps.cache-key.outputs.key }}

--- a/LibPkgConf.xs
+++ b/LibPkgConf.xs
@@ -117,7 +117,7 @@ solve_flags(pkgconf_pkg_t *package, my_client_t *client, int type,
 #if LIBPKGCONF_VERSION >= 10900
   if (sizeof(query_string) <=
       snprintf(query_string, sizeof(query_string), "%s = %s",
-      package->realname, package->version))
+      package->id, package->version))
     false;
   pkgconf_queue_push(&query, query_string);
   if (loaded_from_file)

--- a/LibPkgConf.xs
+++ b/LibPkgConf.xs
@@ -467,6 +467,11 @@ _get_string(self, client, type)
      */
     while (len > 1 && buffer[len-2] == '\0') len--;
     SvCUR_set(RETVAL, len-1);
+    /*
+     * Append a space if not already there to mimic pkgconf < 1.9 behaviour.
+     */
+    if (len > 1 && buffer[len-2] != ' ')
+      sv_catpvs(RETVAL, " ");
     pkgconf_fragment_free(&filtered_list);
   OUTPUT:
     RETVAL

--- a/LibPkgConf.xs
+++ b/LibPkgConf.xs
@@ -334,6 +334,10 @@ _package_from_file(self, filename)
     FILE *fp;
     pkgconf_pkg_t *package;
   CODE:
+#if LIBPKGCONF_VERSION >= 20500
+    package = pkgconf_pkg_new_from_path(&self->client, filename, 0);
+    RETVAL = PTR2IV(package);
+#else
     fp = fopen(filename, "r");
     if(fp != NULL) {
 #if LIBPKGCONF_VERSION >= 10900
@@ -344,6 +348,7 @@ _package_from_file(self, filename)
       RETVAL = PTR2IV(package);
     } else
       RETVAL = 0;
+#endif
   OUTPUT:
     RETVAL
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -6,6 +6,7 @@ corpus/lib1/foo1a.pc
 corpus/lib2/bar.pc
 corpus/lib2/foo.pc
 corpus/lib3/foo.pc
+corpus/lib4/bar.pc
 INSTALL
 lib/PkgConfig/LibPkgConf.pm
 lib/PkgConfig/LibPkgConf/Client.pm

--- a/corpus/lib4/bar.pc
+++ b/corpus/lib4/bar.pc
@@ -1,0 +1,4 @@
+Name: foo
+Description: A pkg-config file whose identifier does not match its name
+Version: 1.2.3
+Cflags: -fPIC

--- a/lib/PkgConfig/LibPkgConf/Package.pm
+++ b/lib/PkgConfig/LibPkgConf/Package.pm
@@ -86,7 +86,7 @@ Library flags.  This usually includes things like C<-L/foo/lib> and C<-lfoo>.
 sub libs
 {
   my($self) = @_;
-  $self->_get_string($self->{client}, 0);
+  $self->_get_string($self->{client}, 0, exists $self->{filename});
 }
 
 =head2 libs_static
@@ -98,7 +98,7 @@ Static library flags.
 sub libs_static
 {
   my($self) = @_;
-  $self->_get_string($self->{client}, 1);
+  $self->_get_string($self->{client}, 1, exists $self->{filename});
 }
 
 =head2 cflags
@@ -110,7 +110,7 @@ Compiler flags.  This usually includes things like C<-I/foo/include> and C<-DFOO
 sub cflags
 {
   my($self) = @_;
-  $self->_get_string($self->{client}, 2);
+  $self->_get_string($self->{client}, 2, exists $self->{filename});
 }
 
 =head2 cflags_static
@@ -122,7 +122,7 @@ Static compiler flags.
 sub cflags_static
 {
   my($self) = @_;
-  $self->_get_string($self->{client}, 3);
+  $self->_get_string($self->{client}, 3, exists $self->{filename});
 }
 
 =head2 list_libs
@@ -144,7 +144,7 @@ sub list_libs
 {
   my($self) = @_;
   require PkgConfig::LibPkgConf::Fragment;
-  map { bless $_, 'PkgConfig::LibPkgConf::Fragment' } $self->_get_list($self->{client}, 0);
+  map { bless $_, 'PkgConfig::LibPkgConf::Fragment' } $self->_get_list($self->{client}, 0, exists $self->{filename});
 }
 
 =head2 list_libs_static
@@ -159,7 +159,7 @@ sub list_libs_static
 {
   my($self) = @_;
   require PkgConfig::LibPkgConf::Fragment;
-  map { bless $_, 'PkgConfig::LibPkgConf::Fragment' } $self->_get_list($self->{client}, 1);
+  map { bless $_, 'PkgConfig::LibPkgConf::Fragment' } $self->_get_list($self->{client}, 1, exists $self->{filename});
 }
 
 =head2 list_cflags
@@ -181,7 +181,7 @@ sub list_cflags
 {
   my($self) = @_;
   require PkgConfig::LibPkgConf::Fragment;
-  map { bless $_, 'PkgConfig::LibPkgConf::Fragment' } $self->_get_list($self->{client}, 2);
+  map { bless $_, 'PkgConfig::LibPkgConf::Fragment' } $self->_get_list($self->{client}, 2, exists $self->{filename});
 }
 
 =head2 list_cflags_static
@@ -196,7 +196,7 @@ sub list_cflags_static
 {
   my($self) = @_;
   require PkgConfig::LibPkgConf::Fragment;
-  map { bless $_, 'PkgConfig::LibPkgConf::Fragment' } $self->_get_list($self->{client}, 3);
+  map { bless $_, 'PkgConfig::LibPkgConf::Fragment' } $self->_get_list($self->{client}, 3, exists $self->{filename});
 }
 
 =head2 variable

--- a/t/client.t
+++ b/t/client.t
@@ -206,7 +206,7 @@ subtest 'path attributes' => sub {
 
   mkpath "$root/$_", 0, 0700 for qw(
     foo bar baz ralph trans formers foo/lib bar/lib trans/lib formers/lib
-    foo/include bar/include trans/include formers/include
+    /foo/include bar/include trans/include formers/include
   );
 
   subtest 'search path' => sub {
@@ -292,6 +292,18 @@ subtest 'global' => sub {
     is( $pkg->cflags, '-fPIC -I/klingon/autobot/force/include/foo ' );
 
   };
+
+};
+
+subtest 'a package with a different name' => sub {
+
+  my $client = PkgConfig::LibPkgConf::Client->new( path => 'corpus/lib4' );
+
+  is( $client->find('foo'), undef, 'A human-readable name foo is ignored');
+
+  my $pkg = $client->find('bar');
+  isnt( $pkg, undef, 'An identifier bar is found' );
+  is( $pkg->cflags, '-fPIC ', 'Cflags are retrieved' );
 
 };
 

--- a/t/client.t
+++ b/t/client.t
@@ -289,7 +289,7 @@ subtest 'global' => sub {
     my $client = PkgConfig::LibPkgConf::Client->new( path => 'corpus/lib1', global => { prefix => '/klingon/autobot/force' } );
     my $pkg = $client->find('foo');
 
-    is( $pkg->cflags, '-fPIC -I/klingon/autobot/force/include/foo' );
+    is( $pkg->cflags, '-fPIC -I/klingon/autobot/force/include/foo ' );
 
   };
 

--- a/t/client.t
+++ b/t/client.t
@@ -289,7 +289,7 @@ subtest 'global' => sub {
     my $client = PkgConfig::LibPkgConf::Client->new( path => 'corpus/lib1', global => { prefix => '/klingon/autobot/force' } );
     my $pkg = $client->find('foo');
 
-    is( $pkg->cflags, '-fPIC -I/klingon/autobot/force/include/foo ' );
+    is( $pkg->cflags, '-fPIC -I/klingon/autobot/force/include/foo' );
 
   };
 

--- a/t/package.t
+++ b/t/package.t
@@ -43,9 +43,9 @@ subtest 'find' => sub {
   is $pkg->version, '1.2.3', 'version';
   is $pkg->description, 'A testing pkg-config file', 'description';
 
-  is $pkg->libs, '-L/test/lib -lfoo', 'libs';
-  is $pkg->cflags, '-fPIC -I/test/include/foo', 'cflags';
-  is $pkg->cflags_static, '-fPIC -I/test/include/foo -DFOO_STATIC', 'cflags_static';
+  is $pkg->libs, '-L/test/lib -lfoo ', 'libs';
+  is $pkg->cflags, '-fPIC -I/test/include/foo ', 'cflags';
+  is $pkg->cflags_static, '-fPIC -I/test/include/foo -DFOO_STATIC ', 'cflags_static';
 
   my @libs           = $pkg->list_libs;
   my @cflags         = $pkg->list_cflags;
@@ -101,9 +101,9 @@ subtest 'package_from_file' => sub {
   is $pkg->version, '1.2.3', 'version';
   is $pkg->description, 'A testing pkg-config file', 'description';
 
-  is $pkg->libs, '-L/test/lib -lfoo', 'libs';
-  is $pkg->cflags, '-fPIC -I/test/include/foo', 'cflags';
-  is $pkg->cflags_static, '-fPIC -I/test/include/foo -DFOO_STATIC', 'cflags_static';
+  is $pkg->libs, '-L/test/lib -lfoo ', 'libs';
+  is $pkg->cflags, '-fPIC -I/test/include/foo ', 'cflags';
+  is $pkg->cflags_static, '-fPIC -I/test/include/foo -DFOO_STATIC ', 'cflags_static';
 
   my @libs           = $pkg->list_libs;
   my @cflags         = $pkg->list_cflags;
@@ -146,8 +146,8 @@ subtest 'filte sys' => sub {
   
   my $pkg = $client->find('foo');
 
-  is $pkg->libs,   '-lfoo', 'libs';
-  is $pkg->cflags, '-fPIC', 'cflags';
+  is $pkg->libs,   '-lfoo ', 'libs';
+  is $pkg->cflags, '-fPIC ', 'cflags';
 
 };
 
@@ -162,8 +162,8 @@ subtest 'quotes and spaces' => sub {
   my $pkg = $client->find('foo1');
 
   TODO: { local $TODO = 'not important';
-  is $pkg->libs, "-L/test/lib -LC:/Program\\ Files/Foo\\ App/lib -lfoo1";
-  is $pkg->cflags, '-fPIC -I/test/include/foo1 -IC:/Program\\ Files/Foo\\ App/include';
+  is $pkg->libs, "-L/test/lib -LC:/Program\\ Files/Foo\\ App/lib -lfoo1 ";
+  is $pkg->cflags, '-fPIC -I/test/include/foo1 -IC:/Program\\ Files/Foo\\ App/include ';
   };
 
   is [map { "$_" } $pkg->list_libs]->[1], '-LC:/Program Files/Foo App/lib';
@@ -180,9 +180,9 @@ subtest 'package with prereq' => sub {
   
   my $pkg = $client->find('foo');
   
-  is $pkg->libs,           '-L/test/lib -lfoo -L/test2/lib -lbar';
-  is $pkg->cflags,         '-I/test/include/foo -I/test2/include/bar';
-  is $pkg->cflags_static,  '-I/test/include/foo -I/test2/include/bar -DFOO_STATIC -DBAR_STATIC';
+  is $pkg->libs,           '-L/test/lib -lfoo -L/test2/lib -lbar ';
+  is $pkg->cflags,         '-I/test/include/foo -I/test2/include/bar ';
+  is $pkg->cflags_static,  '-I/test/include/foo -I/test2/include/bar -DFOO_STATIC -DBAR_STATIC ';
 
   is_deeply [$pkg->list_libs],           [qw( -L/test/lib -lfoo -L/test2/lib -lbar )];
   is_deeply [$pkg->list_cflags],         [qw( -I/test/include/foo -I/test2/include/bar )];
@@ -200,7 +200,7 @@ subtest 'package with static libs' => sub {
   
   my $pkg = $client->find('foo');
 
-  is $pkg->libs_static, '-L/test/lib -lfoo -lbar -lbaz';
+  is $pkg->libs_static, '-L/test/lib -lfoo -lbar -lbaz ';
   is_deeply [$pkg->list_libs_static], [qw( -L/test/lib -lfoo -lbar -lbaz )];
 
 };

--- a/t/package.t
+++ b/t/package.t
@@ -94,7 +94,7 @@ subtest 'package_from_file' => sub {
   note "cflags         = @{[ $pkg->cflags ]}";
   note "cflags_static  = @{[ $pkg->cflags_static ]}";
 
-  is $pkg->refcount, 2, 'refcount';
+  is $pkg->refcount, 1, 'refcount';
   is $pkg->id, 'foo', 'id';
   is $pkg->filename, 'corpus/lib1/foo.pc', 'filename';
   is $pkg->realname, 'foo', 'realname';

--- a/t/package.t
+++ b/t/package.t
@@ -43,9 +43,9 @@ subtest 'find' => sub {
   is $pkg->version, '1.2.3', 'version';
   is $pkg->description, 'A testing pkg-config file', 'description';
 
-  is $pkg->libs, '-L/test/lib -lfoo ', 'libs';
-  is $pkg->cflags, '-fPIC -I/test/include/foo ', 'cflags';
-  is $pkg->cflags_static, '-fPIC -I/test/include/foo -DFOO_STATIC ', 'cflags_static';
+  is $pkg->libs, '-L/test/lib -lfoo', 'libs';
+  is $pkg->cflags, '-fPIC -I/test/include/foo', 'cflags';
+  is $pkg->cflags_static, '-fPIC -I/test/include/foo -DFOO_STATIC', 'cflags_static';
 
   my @libs           = $pkg->list_libs;
   my @cflags         = $pkg->list_cflags;
@@ -101,9 +101,9 @@ subtest 'package_from_file' => sub {
   is $pkg->version, '1.2.3', 'version';
   is $pkg->description, 'A testing pkg-config file', 'description';
 
-  is $pkg->libs, '-L/test/lib -lfoo ', 'libs';
-  is $pkg->cflags, '-fPIC -I/test/include/foo ', 'cflags';
-  is $pkg->cflags_static, '-fPIC -I/test/include/foo -DFOO_STATIC ', 'cflags_static';
+  is $pkg->libs, '-L/test/lib -lfoo', 'libs';
+  is $pkg->cflags, '-fPIC -I/test/include/foo', 'cflags';
+  is $pkg->cflags_static, '-fPIC -I/test/include/foo -DFOO_STATIC', 'cflags_static';
 
   my @libs           = $pkg->list_libs;
   my @cflags         = $pkg->list_cflags;
@@ -146,8 +146,8 @@ subtest 'filte sys' => sub {
   
   my $pkg = $client->find('foo');
 
-  is $pkg->libs,   '-lfoo ', 'libs';  
-  is $pkg->cflags, '-fPIC ', 'cflags';
+  is $pkg->libs,   '-lfoo', 'libs';
+  is $pkg->cflags, '-fPIC', 'cflags';
 
 };
 
@@ -162,8 +162,8 @@ subtest 'quotes and spaces' => sub {
   my $pkg = $client->find('foo1');
 
   TODO: { local $TODO = 'not important';
-  is $pkg->libs, "-L/test/lib -LC:/Program\\ Files/Foo\\ App/lib -lfoo1 ";
-  is $pkg->cflags, '-fPIC -I/test/include/foo1 -IC:/Program\\ Files/Foo\\ App/include ';
+  is $pkg->libs, "-L/test/lib -LC:/Program\\ Files/Foo\\ App/lib -lfoo1";
+  is $pkg->cflags, '-fPIC -I/test/include/foo1 -IC:/Program\\ Files/Foo\\ App/include';
   };
 
   is [map { "$_" } $pkg->list_libs]->[1], '-LC:/Program Files/Foo App/lib';
@@ -180,9 +180,9 @@ subtest 'package with prereq' => sub {
   
   my $pkg = $client->find('foo');
   
-  is $pkg->libs,           '-L/test/lib -lfoo -L/test2/lib -lbar ';
-  is $pkg->cflags,         '-I/test/include/foo -I/test2/include/bar ';
-  is $pkg->cflags_static,  '-I/test/include/foo -I/test2/include/bar -DFOO_STATIC -DBAR_STATIC ';
+  is $pkg->libs,           '-L/test/lib -lfoo -L/test2/lib -lbar';
+  is $pkg->cflags,         '-I/test/include/foo -I/test2/include/bar';
+  is $pkg->cflags_static,  '-I/test/include/foo -I/test2/include/bar -DFOO_STATIC -DBAR_STATIC';
 
   is_deeply [$pkg->list_libs],           [qw( -L/test/lib -lfoo -L/test2/lib -lbar )];
   is_deeply [$pkg->list_cflags],         [qw( -I/test/include/foo -I/test2/include/bar )];
@@ -200,7 +200,7 @@ subtest 'package with static libs' => sub {
   
   my $pkg = $client->find('foo');
 
-  is $pkg->libs_static, '-L/test/lib -lfoo -lbar -lbaz ';
+  is $pkg->libs_static, '-L/test/lib -lfoo -lbar -lbaz';
   is_deeply [$pkg->list_libs_static], [qw( -L/test/lib -lfoo -lbar -lbaz )];
 
 };

--- a/t/package.t
+++ b/t/package.t
@@ -94,7 +94,7 @@ subtest 'package_from_file' => sub {
   note "cflags         = @{[ $pkg->cflags ]}";
   note "cflags_static  = @{[ $pkg->cflags_static ]}";
 
-  is $pkg->refcount, 1, 'refcount';
+  is $pkg->refcount, 2, 'refcount';
   is $pkg->id, 'foo', 'id';
   is $pkg->filename, 'corpus/lib1/foo.pc', 'filename';
   is $pkg->realname, 'foo', 'realname';

--- a/t/simple.t
+++ b/t/simple.t
@@ -18,11 +18,11 @@ subtest 'simple stuff' => sub {
   eval { pkgconf_version('bogus') };
   like $@, qr{package bogus not found}, 'pkgconf_version not found';
 
-  is pkgconf_cflags('foo'), '-fPIC -I/test/include/foo ', 'pkgconf_cflags found';
+  is pkgconf_cflags('foo'), '-fPIC -I/test/include/foo', 'pkgconf_cflags found';
   eval { pkgconf_cflags('bogus') };
   like $@, qr{package bogus not found}, 'pkgconf_cflags not found';
 
-  is pkgconf_libs('foo'), '-L/test/lib -lfoo ', 'pkgconf_libs found';
+  is pkgconf_libs('foo'), '-L/test/lib -lfoo', 'pkgconf_libs found';
   eval { pkgconf_libs('bogus') };
   like $@, qr{package bogus not found}, 'pkgconf_libs not found';
 };
@@ -31,8 +31,8 @@ subtest 'static' => sub {
 
   local $ENV{PKG_CONFIG_PATH} = 'corpus/lib3';
   
-  is pkgconf_cflags_static('foo'), '-I/test/include/foo -DFOO_STATIC ', 'cflags';  
-  is pkgconf_libs_static('foo'), '-L/test/lib -lfoo -lbar -lbaz ', 'libs';  
+  is pkgconf_cflags_static('foo'), '-I/test/include/foo -DFOO_STATIC', 'cflags';
+  is pkgconf_libs_static('foo'), '-L/test/lib -lfoo -lbar -lbaz', 'libs';
 
 };
 

--- a/t/simple.t
+++ b/t/simple.t
@@ -18,11 +18,11 @@ subtest 'simple stuff' => sub {
   eval { pkgconf_version('bogus') };
   like $@, qr{package bogus not found}, 'pkgconf_version not found';
 
-  is pkgconf_cflags('foo'), '-fPIC -I/test/include/foo', 'pkgconf_cflags found';
+  is pkgconf_cflags('foo'), '-fPIC -I/test/include/foo ', 'pkgconf_cflags found';
   eval { pkgconf_cflags('bogus') };
   like $@, qr{package bogus not found}, 'pkgconf_cflags not found';
 
-  is pkgconf_libs('foo'), '-L/test/lib -lfoo', 'pkgconf_libs found';
+  is pkgconf_libs('foo'), '-L/test/lib -lfoo ', 'pkgconf_libs found';
   eval { pkgconf_libs('bogus') };
   like $@, qr{package bogus not found}, 'pkgconf_libs not found';
 };
@@ -31,8 +31,8 @@ subtest 'static' => sub {
 
   local $ENV{PKG_CONFIG_PATH} = 'corpus/lib3';
   
-  is pkgconf_cflags_static('foo'), '-I/test/include/foo -DFOO_STATIC', 'cflags';
-  is pkgconf_libs_static('foo'), '-L/test/lib -lfoo -lbar -lbaz', 'libs';
+  is pkgconf_cflags_static('foo'), '-I/test/include/foo -DFOO_STATIC ', 'cflags';
+  is pkgconf_libs_static('foo'), '-L/test/lib -lfoo -lbar -lbaz ', 'libs';
 
 };
 


### PR DESCRIPTION
This patchset adapts to changes in pkgconf 1.9 and 2.5.0.

Upstream stopped adding trailing spaces to cflags/libs strings. This patch puts them back as that would break a use case when one concatenates various flags for a command line.

Most complex part is dealing with changed pkgconf dependency solver. pkgconf now returns only direct cflags/libs. One needs to use a pkgconf solver which populates an in-client cache and stores intermediate results into a dedicated PKGCONF_PKG_PROPF_VIRTUAL package.

Because the solver ignores packages loaded from a file, this patch also temporarily injects these packages into a cache to retrieve flags including dependencies.

All tests pass with pkgconf 1.9.4 and 1.8.0.

https://github.com/PerlAlien/PkgConfig-LibPkgConf/issues/15